### PR TITLE
Loosen dependency on smarter_csv

### DIFF
--- a/banking_data.gemspec
+++ b/banking_data.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport'
   gem.add_dependency 'activemodel'
-  gem.add_dependency 'smarter_csv', '~> 1.1.0'
+  gem.add_dependency 'smarter_csv', '~> 1.1'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'coveralls'


### PR DESCRIPTION
Using `~> 1.1.0` is very restrictive (same as >=1.1.0 and <1.2), so unless there is a really good reason, you should omit the patch level (third digit) when using the pessimistic operator: `-> 1.1` (same as >=1.1 and < 2). Why? [Semver](https://semver.org/spec/v0.1.0.html) requires the major (first digit) to be increase when breaking changes are introduced. Minor (second digit) is for non-breaking additons and patch level (third digit) for non-breaking fixes. By using the pessimistic operator as you do, you might prevent security relevant updates from being pulled until you update the dependency.